### PR TITLE
feat: set persistent env var, update readme and create env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PROJECT_ROOT=''

--- a/README.md
+++ b/README.md
@@ -23,8 +23,29 @@ This install runs on gitpod inti, docs here on [Gitpod init yml](https://www.git
 
 ### Changing script perms
 
+> Great resource on linux permissions by Redhat can be [found here](https://www.redhat.com/sysadmin/linux-file-permissions-explained).
+
 In order to run the script without using the `source` command you need to grant executable permissions to the user on the file. To do this you need to run the below:
 
-`chmod u+x ./bin/install_tf_cli`
+```
+chmod u+x ./bin/install_tf_cli
+```
 
-> Great resource on linux permissions by Redhat can be [found here](https://www.redhat.com/sysadmin/linux-file-permissions-explained).
+
+## Working with env vars
+
+You can list all env vars using `env` command or filter them by piping them into `grep`.
+
+> To unset a env var you can use `unset [ENV_NAME] // e.g. unset MY_ENV_VAR` and note they only apply to the terminal you're using.
+
+Set them using `export` in terminal and prinnt them our using `echo $[ENV_VAR_NAME`.  
+
+#### Persisting Gitpod secrets
+
+We can persist secret variables in different gitpod workspaces by storing them in gitpod secrets. Do this using:
+
+```
+gp env HELLO='world'
+```
+
+Or you can set non-secret env vars in `gitpod.yml`.

--- a/bin/install_tf_cli
+++ b/bin/install_tf_cli
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+cd ../
+
 wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt update && sudo apt install terraform curl -y
+
+cd $PROJECT_ROOT


### PR DESCRIPTION
### Context

- Add `PROJECT_ROOT` env var to gitpod workspace
- Use the new env var in the tf setup script to install deps in the parent directory
- Update readme